### PR TITLE
Adds .idea/ to the .gitignore file

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -19,6 +19,7 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+projects_storage/
 
 # Virtual Environment
 venv/
@@ -52,3 +53,5 @@ htmlcov/
 # OS
 .DS_Store
 Thumbs.db
+
+.idea/


### PR DESCRIPTION
This pull request updates the `.gitignore` file in the `backend/` directory to improve exclusion of development and environment-specific files. The changes help prevent accidental commits of local project data and IDE configuration files.

Project storage and IDE files exclusion:

* Added `projects_storage/` to `.gitignore` to prevent local project data from being tracked.
* Added `.idea/` to `.gitignore` to exclude JetBrains IDE configuration files from version control.