### PR TITLE
chore: update CI pr branch to main

### DIFF
--- a/.github/workflows/backend_dev.yml
+++ b/.github/workflows/backend_dev.yml
@@ -2,7 +2,7 @@ name: Backend - Compile & Smoke Test
 
 on:
   pull_request:
-    branches: [ develop ]
+    branches: [ main ]
 
 jobs:
   backend-check:

--- a/.github/workflows/frontend_dev.yml
+++ b/.github/workflows/frontend_dev.yml
@@ -2,7 +2,7 @@ name: Frontend - Build & Lint
 
 on:
   pull_request:
-    branches: [ develop ]
+    branches: [ main ]
 
 jobs:
   frontend-check:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to trigger on pull requests targeting the `main` branch instead of the `develop` branch. This ensures that CI checks run for pull requests against the primary branch.

Workflow configuration updates:

* Changed the `Backend - Compile & Smoke Test` workflow in `.github/workflows/backend_dev.yml` to run on pull requests to the `main` branch.
* Changed the `Frontend - Build & Lint` workflow in `.github/workflows/frontend_dev.yml` to run on pull requests to the `main` branch.